### PR TITLE
0.1.2

### DIFF
--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,12 +1,22 @@
-import { Text, StyleSheet, Pressable, Button } from 'react-native';
-import { useTheme, ZSContainer } from 'zs-ui';
+import { Text, StyleSheet, Pressable, Button, ScrollView } from 'react-native';
+import { useTheme, ZSContainer, ZSContainerRef } from 'zs-ui';
 import { router } from 'expo-router';
+import { useRef } from 'react';
 
 export default function Home() {
   const { palette: { toggleTheme, mode } } = useTheme();
+  const containerRef = useRef<ZSContainerRef>(null);
+
+  const handleScrollToTop = () => {
+    containerRef.current?.scrollTo({ y: 0, animated: true });
+  };
 
   return (
-    <ZSContainer edges={[]} style={{ gap: 20, padding: 30 }}>
+    <ZSContainer 
+      ref={containerRef}
+      edges={[]} 
+      style={{ gap: 20, padding: 30 }}
+    >
       <Pressable onPress={toggleTheme} style={[styles.button, { backgroundColor: 'orange' }]}>
         <Text style={styles.buttonText}>현재 모드: {mode}</Text>
       </Pressable>
@@ -14,6 +24,8 @@ export default function Home() {
       <Button title='Theme 예제' onPress={() => router.push('/ThemeExample')} />
       <Button title='Layout 예제' onPress={() => router.push('/LayoutExample')} />
       <Button title='Overlay 예제' onPress={() => router.push('/OverlayExample')} />
+      
+      <Button title='맨 위로 스크롤' onPress={handleScrollToTop} />
     </ZSContainer>
   );
 }

--- a/example/package.json
+++ b/example/package.json
@@ -20,7 +20,7 @@
     "react": "18.3.1",
     "react-native": "0.76.9",
     "react-native-reanimated": "~3.17.4",
-    "react-native-safe-area-context": "4.12.0",
+    "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.4.0",
     "react-native-svg": "15.8.0"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4888,10 +4888,10 @@ react-native-reanimated@~3.17.4:
     invariant "^2.2.4"
     react-native-is-edge-to-edge "1.1.7"
 
-react-native-safe-area-context@4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz#17868522a55bbc6757418c94a1b4abdda6b045d9"
-  integrity sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==
+react-native-safe-area-context@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz#04b51940408c114f75628a12a93569d30c525454"
+  integrity sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==
 
 react-native-screens@~4.4.0:
   version "4.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "18.3.1",
     "react-native": ">=0.76.9",
     "react-native-reanimated": ">=3.17.4",
-    "react-native-safe-area-context": "4.12.0",
+    "react-native-safe-area-context": "5.4.0",
     "expo-navigation-bar": ">=4.0.7",
     "react-native-svg": "15.8.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ import {
   ShadowLevel,
   ShadowStyle,
 } from "./ui/types";
+import { ZSContainerRef } from "./ui/ZSContainer";
 
 export type {
   ThemeProviderProps,
@@ -138,5 +139,6 @@ export type {
   BottomSheetOptions,
   RadioOption,
   ShadowLevel,
-  ShadowStyle
+  ShadowStyle,
+  ZSContainerRef
 };

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -5,7 +5,7 @@ import ViewAtom from '../atoms/ViewAtom';
 import ScrollViewAtom from '../atoms/ScrollViewAtom';
 import { useTheme } from '../../model/useThemeProvider';
 
-type ZSContainerProps = ViewProps & {
+export type ZSContainerProps = ViewProps & {
   backgroundColor?: string;
   isLoader?: boolean;
   statusBarColor?: string;
@@ -22,7 +22,9 @@ type ZSContainerProps = ViewProps & {
   keyboardScrollExtraOffset?: number;
 };
 
-const ZSContainer = forwardRef<ScrollView, ZSContainerProps>(function ZSContainer(
+export type ZSContainerRef = ScrollView;
+
+const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSContainer(
   {
     backgroundColor,
     isLoader = false,
@@ -37,7 +39,7 @@ const ZSContainer = forwardRef<ScrollView, ZSContainerProps>(function ZSContaine
     keyboardVerticalOffset,
     behavior,
     automaticallyAdjustKeyboardInsets = true,
-    keyboardScrollExtraOffset,
+    keyboardScrollExtraOffset = 100,
     ...props
   },
   forwardedRef

--- a/yarn.lock
+++ b/yarn.lock
@@ -5172,10 +5172,10 @@ react-native-reanimated@>=3.17.4:
     invariant "^2.2.4"
     react-native-is-edge-to-edge "1.1.7"
 
-react-native-safe-area-context@4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz#17868522a55bbc6757418c94a1b4abdda6b045d9"
-  integrity sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==
+react-native-safe-area-context@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz#04b51940408c114f75628a12a93569d30c525454"
+  integrity sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==
 
 react-native-svg@15.8.0:
   version "15.8.0"


### PR DESCRIPTION
## Sourcery의 요약

ZSContainer 컴포넌트와 예제 앱에 새로운 스크롤 기능 및 타입 내보내기 추가

새로운 기능:
- 예제 앱에 맨 위로 스크롤하는 기능 추가
- 외부 사용을 위한 ZSContainerRef 타입 내보내기

개선 사항:
- ZSContainer를 향상된 타입과 함께 forwardRef 컴포넌트로 노출
- 기본 keyboardScrollExtraOffset 값을 100으로 설정

기타 작업:
- 패키지 버전을 0.1.2로 업데이트
- react-native-safe-area-context 의존성을 5.4.0으로 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update ZSContainer component and example app with new scrolling functionality and type exports

New Features:
- Add scroll to top functionality in the example app
- Export ZSContainerRef type for external use

Enhancements:
- Expose ZSContainer as a forwardRef component with improved typing
- Set default keyboardScrollExtraOffset to 100

Chores:
- Bump package version to 0.1.2
- Update react-native-safe-area-context dependency to 5.4.0

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a scroll-to-top button to the Home screen for easy navigation.
- **Dependency Updates**
  - Updated "react-native-safe-area-context" to version 5.4.0.
- **Other Improvements**
  - Improved type exports for container components.
  - Set a default value for keyboard scroll offset in container components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->