### PR TITLE
0.1.3

### DIFF
--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -6,7 +6,7 @@ import SnackBar from '../src/ui/Snackbar';
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
-      <ThemeProvider>
+      <ThemeProvider isDarkModeEnabled={false}>
         <OverlayProvider customSnackbar={SnackBar}>
           <Stack
             screenOptions={{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/model/useThemeProvider.tsx
+++ b/src/model/useThemeProvider.tsx
@@ -10,6 +10,7 @@ import elevation, { ElevationStyles } from '../theme/elevation';
 export interface ThemeProviderProps {
   themeFonts?: ThemeFonts;
   children: React.ReactNode;
+  isDarkModeEnabled?: boolean;
 }
 
 export interface ThemeProps {
@@ -35,27 +36,31 @@ export const useTheme = () => {
   return context;
 }
 
-export const ThemeProvider: React.FC<ThemeProviderProps> = ({ themeFonts, children }) => {
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ themeFonts, children, isDarkModeEnabled = true }) => {
   const systemColorScheme = useColorScheme(); // 시스템 다크 모드 감지
-  const [isUsingSystemColorScheme, setUseSystemColorScheme] = useState(true);
-  const [mode, setMode] = useState<'light' | 'dark'>(systemColorScheme === 'dark' ? 'dark' : 'light');
+  const [isUsingSystemColorScheme, setUseSystemColorScheme] = useState(isDarkModeEnabled ? true : false);
+  const [mode, setMode] = useState<'light' | 'dark'>(isDarkModeEnabled ? (systemColorScheme === 'dark' ? 'dark' : 'light') : 'light');
 
   // AsyncStorage에서 시스템 모드 사용 설정 값 로드
   useEffect(() => {
     const loadSettings = async () => {
       let isMounted = true;
       try {
-        const storedUseSystemColorScheme = await AsyncStorage.getItem('useSystemColorScheme');
-        const storedMode = await AsyncStorage.getItem('themeMode');
-
         if (isMounted) {
-          if (storedUseSystemColorScheme !== null) {
-            setUseSystemColorScheme(storedUseSystemColorScheme === 'true');
-          }
-          if (storedMode) {
-            setMode(storedMode === 'dark' ? 'dark' : 'light');
+          if (isDarkModeEnabled) {
+            const storedUseSystemColorScheme = await AsyncStorage.getItem('useSystemColorScheme');
+            const storedMode = await AsyncStorage.getItem('themeMode');
+
+            if (storedUseSystemColorScheme !== null) {
+              setUseSystemColorScheme(storedUseSystemColorScheme === 'true');
+            }
+            if (storedMode) {
+              setMode(storedMode === 'dark' ? 'dark' : 'light');
+            } else {
+              setMode(systemColorScheme === 'dark' ? 'dark' : 'light');
+            }
           } else {
-            setMode(systemColorScheme === 'dark' ? 'dark' : 'light');
+            setMode('light');
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Sourcery 요약

ThemeProvider에 선택적 다크 모드 구성 추가

새로운 기능:
- 다크 모드 기능을 제어하는 선택적 `isDarkModeEnabled` prop을 도입합니다.

개선 사항:
- 다크 모드 비활성화를 지원하도록 테마 제공자를 수정합니다.
- 다크 모드 구성을 고려하도록 테마 모드 초기화 로직을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional dark mode configuration to ThemeProvider

New Features:
- Introduce an optional `isDarkModeEnabled` prop to control dark mode functionality

Enhancements:
- Modify theme provider to support disabling dark mode
- Update theme mode initialization logic to respect dark mode configuration

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to explicitly enable or disable dark mode support in the app’s theme settings.
- **Other**
	- Updated the app version to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->