### PR TITLE
0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/overlay/AlertOverlay/index.tsx
+++ b/src/overlay/AlertOverlay/index.tsx
@@ -137,6 +137,7 @@ const createStyles = ({ background }: { background: ThemeBackground; }) =>
       paddingBottom: 18,
       paddingTop: 24,
       paddingHorizontal: 20,
+      maxWidth: 500,
     },
   });
 

--- a/src/overlay/BottomSheetOverlay/index.tsx
+++ b/src/overlay/BottomSheetOverlay/index.tsx
@@ -172,6 +172,7 @@ const styles = StyleSheet.create({
     borderRadius: 26,
     overflow: 'hidden',
     zIndex: Z_INDEX_VALUE.BOTTOM_SHEET2,
+    maxWidth: 600,
   },
   pressableView: {
     width: '100%',

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useState, useEffect, useImperativeHandle, forwardRef, useRef } from 'react';
-import { ViewProps, KeyboardAvoidingView, StatusBar, StyleSheet, Dimensions, ActivityIndicator, ScrollView, NativeSyntheticEvent, NativeScrollEvent, Keyboard, View } from 'react-native';
+import { ViewProps, KeyboardAvoidingView, StatusBar, StyleSheet, Dimensions, ActivityIndicator, ScrollView, NativeSyntheticEvent, NativeScrollEvent, Keyboard, View, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import ScrollViewAtom from '../atoms/ScrollViewAtom';
 import { useTheme } from '../../model/useThemeProvider';
@@ -60,7 +60,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
   const positionRef = useRef<number | null>(0);
   const scrollViewRef = useRef<ScrollView>(null);
   const lastTouchY = useRef<number | null>(0);
-  const windowWidth = Dimensions.get('window').width;
+  const { width: windowWidth } = useWindowDimensions();
   const isSplitView = (windowWidth >= splitBreakpoint) && rightComponent;
 
   useImperativeHandle(forwardedRef, () => scrollViewRef.current as ScrollView, []);
@@ -140,7 +140,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
           )
         }
 
-        {rightComponent && (
+        {rightComponent && isSplitView && (
           <View style={[styles.splitView, { width: rightWidth }]}>
             {rightComponent}
           </View>

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -42,7 +42,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
     scrollViewDisabled = false,
     topComponent,
     bottomComponent,
-    rightComponent = <View style={{ flex: 1, backgroundColor: 'red' }}></View>,
+    rightComponent,
     splitBreakpoint = 700,
     splitRatio = 0.5,
     showsVerticalScrollIndicator = true,

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useState, useEffect, useImperativeHandle, forwardRef, useRef } from 'react';
-import { ViewProps, KeyboardAvoidingView, StatusBar, StyleSheet, Dimensions, ActivityIndicator, ScrollView, NativeSyntheticEvent, NativeScrollEvent, Keyboard, useWindowDimensions, View } from 'react-native';
+import { ViewProps, KeyboardAvoidingView, StatusBar, StyleSheet, Dimensions, ActivityIndicator, ScrollView, NativeSyntheticEvent, NativeScrollEvent, Keyboard, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import ScrollViewAtom from '../atoms/ScrollViewAtom';
 import { useTheme } from '../../model/useThemeProvider';
@@ -56,11 +56,11 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
   forwardedRef
 ) {
   const { palette } = useTheme();
-  const { width: windowWidth } = useWindowDimensions();
   const [isDelayed, setIsDelayed] = useState(true);
   const positionRef = useRef<number | null>(0);
   const scrollViewRef = useRef<ScrollView>(null);
   const lastTouchY = useRef<number | null>(0);
+  const windowWidth = Dimensions.get('window').width;
   const isSplitView = (windowWidth >= splitBreakpoint) && rightComponent;
 
   useImperativeHandle(forwardedRef, () => scrollViewRef.current as ScrollView, []);


### PR DESCRIPTION
## Sourcery 요약

ZSContainer를 리팩터링하여 반응형 분할 레이아웃을 활성화하고 스크롤 로직을 단순화합니다. 오버레이 컴포넌트에 maxWidth 제약 조건을 추가하고 UI 패키지 버전을 0.1.8로 올립니다.

새로운 기능:
- rightComponent, splitBreakpoint, splitRatio props를 통해 ZSContainer에서 반응형 분할 뷰 레이아웃을 지원합니다.

개선 사항:
- ZSContainer를 리팩터링하여 useWindowDimensions를 사용하고, isScrollView를 scrollViewDisabled로 대체하고, 콘텐츠 렌더링을 통합합니다.
- AlertOverlay (500) 및 BottomSheetOverlay (600)에 maxWidth 제한을 추가합니다.

잡일:
- package.json 버전을 0.1.8로 올립니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor ZSContainer to enable responsive split layouts and simplify scrolling logic, add maxWidth constraints to overlay components, and bump the UI package to version 0.1.8

New Features:
- Support a responsive split-view layout in ZSContainer via rightComponent, splitBreakpoint, and splitRatio props

Enhancements:
- Refactor ZSContainer to use useWindowDimensions, replace isScrollView with scrollViewDisabled, and unify content rendering
- Add maxWidth limits to AlertOverlay (500) and BottomSheetOverlay (600)

Chores:
- Bump package.json version to 0.1.8

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a responsive split layout for the container, allowing a two-pane display with customizable breakpoint and ratio.
  - Added support for an optional right-side component in the container layout.

- **Refactor**
  - Replaced the previous scroll view toggle prop with a more flexible option for enabling or disabling scroll behavior.

- **Style**
  - Set maximum widths for alert and bottom sheet overlays to improve layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->