### PR TITLE
0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -20,6 +20,7 @@ export type ZSContainerProps = ViewProps & {
   behavior?: 'padding' | 'height' | 'position';
   automaticallyAdjustKeyboardInsets?: boolean;
   keyboardScrollExtraOffset?: number;
+  translucent?: boolean;
   /**
    * 분할 레이아웃이 적용될 최소 화면 너비 (기본값: 700dp)
    * - 일반 스마트폰: ~430dp
@@ -51,6 +52,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
     behavior,
     automaticallyAdjustKeyboardInsets = true,
     keyboardScrollExtraOffset,
+    translucent = false,
     ...props
   },
   forwardedRef
@@ -172,6 +174,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
       <StatusBar
         barStyle={barStyle}
         backgroundColor={statusBarColor || palette.background.base}
+        translucent={translucent}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Sourcery 요약

ZSContainer의 StatusBar에 투명(translucent) 속성을 추가하고 패키지 버전을 0.1.9로 올립니다.

개선 사항:
- ZSContainer에 새로운 boolean 타입의 투명(translucent) 속성(기본값: false)을 도입하여 StatusBar의 투명도를 활성화합니다.

빌드:
- 패키지 버전을 0.1.8에서 0.1.9로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a translucent prop to ZSContainer’s StatusBar and bump the package version to 0.1.9

Enhancements:
- Introduce a new boolean translucent prop (default false) on ZSContainer to enable StatusBar translucency

Build:
- Update package version from 0.1.8 to 0.1.9

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new optional translucent mode in the container component, allowing users to control the translucency of the status bar.

- **Chores**
  - Updated the app version to 0.1.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->