### PR TITLE
0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -20,6 +20,7 @@ export type ZSContainerProps = ViewProps & {
   behavior?: 'padding' | 'height' | 'position';
   automaticallyAdjustKeyboardInsets?: boolean;
   keyboardScrollExtraOffset?: number;
+  translucent?: boolean;
   /**
    * 분할 레이아웃이 적용될 최소 화면 너비 (기본값: 700dp)
    * - 일반 스마트폰: ~430dp
@@ -51,6 +52,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
     behavior,
     automaticallyAdjustKeyboardInsets = true,
     keyboardScrollExtraOffset,
+    translucent = false,
     ...props
   },
   forwardedRef
@@ -172,6 +174,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
       <StatusBar
         barStyle={barStyle}
         backgroundColor={statusBarColor || palette.background.base}
+        translucent={translucent}
       />
     </SafeAreaView>
   );

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -38,7 +38,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
     backgroundColor,
     isLoader = false,
     statusBarColor,
-    barStyle = 'dark-content',
+    barStyle,
     edges = ['top', 'bottom'],
     scrollViewDisabled = false,
     topComponent,
@@ -52,7 +52,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
     behavior,
     automaticallyAdjustKeyboardInsets = true,
     keyboardScrollExtraOffset,
-    translucent = false,
+    translucent,
     ...props
   },
   forwardedRef
@@ -171,11 +171,16 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
           {!isLoader && bottomComponent && bottomComponent}
         </KeyboardAvoidingView>
       )}
-      <StatusBar
-        barStyle={barStyle}
-        backgroundColor={statusBarColor || palette.background.base}
-        translucent={translucent}
-      />
+
+      {
+        (barStyle || statusBarColor || translucent) && (
+          <StatusBar
+            barStyle={barStyle}
+            backgroundColor={statusBarColor || palette.background.base}
+            translucent={translucent}
+          />
+        )
+      }
     </SafeAreaView>
   );
 });


### PR DESCRIPTION
## Sourcery 요약

ZSContainer에서 상태 표시줄 투명도를 설정할 수 있는 선택적 `translucent` 속성을 노출하고, 제공된 속성에 따라 StatusBar의 조건부 렌더링을 조정하며, 패키지 버전을 0.2.0으로 올립니다.

개선 사항:
- ZSContainer에 `translucent` 속성을 추가하고 StatusBar에 전달합니다.
- `barStyle`, `statusBarColor` 또는 `translucent`가 지정된 경우에만 StatusBar를 렌더링합니다.

잡일:
- 패키지 버전을 0.2.0으로 올립니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose optional translucent prop to configure status bar translucency in ZSContainer, adjust conditional rendering of the StatusBar based on provided props, and bump the package version to 0.2.0.

Enhancements:
- Add translucent prop to ZSContainer and propagate it to the StatusBar.
- Render the StatusBar only when barStyle, statusBarColor, or translucent is specified.

Chores:
- Bump package version to 0.2.0.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a translucent status bar in the container component.

- **Refactor**
  - Improved status bar rendering logic to only display when relevant properties are set.

- **Chores**
  - Updated version number to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->