### PR TITLE
0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/overlay/Modality/index.tsx
+++ b/src/overlay/Modality/index.tsx
@@ -24,7 +24,7 @@ function Modality({
   const mainTranslateY = useSharedValue(height);
   const backgroundOpacity = useSharedValue(1);
   const overrideMargin = 10;
-  const mainScreenMargin = overrideMargin; //  + (initialWindowMetrics?.insets.top || insets.top)
+  const mainScreenMargin = insets.top;
   const mainScrrenPadding = (initialWindowMetrics?.insets.bottom || insets.bottom);
 
   // 애니메이션 트리거


### PR DESCRIPTION
## Sourcery 요약

패키지 버전을 0.2.3으로 올리고 오버레이 모달리티가 메인 화면 마진에 대해 안전 영역 상단 삽입을 사용하도록 조정합니다.

개선 사항:
- 패키지 버전을 0.2.3으로 업데이트
- 고정된 오버라이드 값 대신 오버레이 모달리티 mainScreenMargin에 대해 insets.top 사용

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump package version to 0.2.3 and adjust overlay modality to use the safe area top inset for main screen margin.

Enhancements:
- Update package version to 0.2.3
- Use insets.top for overlay modality mainScreenMargin instead of fixed override value

</details>