### PR TITLE
0.3.3

### DIFF
--- a/example/app/LayoutExample.tsx
+++ b/example/app/LayoutExample.tsx
@@ -153,8 +153,21 @@ function LayoutExample(): React.JSX.Element {
             { value: '이메일로 받고싶어요.', index: 'email' },
           ]}
           value={responseType}
-          onSelect={setResponseType} // 콜백 단축
+          onSelect={setResponseType}
           fullWidth
+        />
+      </TitleCard>
+
+      <TitleCard title='ZSRadioGroup Grid'>
+        <ZSRadioGroup
+          options={[
+            { value: '답변이 필요없어요.', index: 'none' },
+            { value: '앱 알림으로 받고싶어요.', index: 'app' },
+            { value: '이메일로 받고싶어요.', index: 'email' },
+          ]}
+          value={responseType}
+          onSelect={setResponseType}
+          rowCount={2}
         />
       </TitleCard>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/ui/ZSRadioGroup/index.tsx
+++ b/src/ui/ZSRadioGroup/index.tsx
@@ -13,10 +13,10 @@ function ZSRadioGroup({
   onSelect,
   containerStyle,
   valueStyle,
-  minWidth,
   disabled = false,
   fullWidth = false,
   selectStyle,
+  rowCount,
 }: {
   options: RadioOption[];
   value?: RadioOption;
@@ -24,9 +24,9 @@ function ZSRadioGroup({
   containerStyle?: ViewProps;
   valueStyle?: ZSTextProps;
   selectStyle?: ZSTextProps;
-  minWidth?: number;
   disabled?: boolean;
   fullWidth?: boolean;
+  rowCount?: 2 | 3;
 }) {
   const { palette } = useTheme();
 
@@ -40,93 +40,101 @@ function ZSRadioGroup({
     <ViewAtom
       style={{
         flexDirection: fullWidth ? 'column' : 'row',
-        gap: 10,
         flexWrap: fullWidth ? 'nowrap' : 'wrap',
         width: '100%',
+        marginHorizontal: fullWidth ? 0 : -5,
       }}
       {...containerStyle}
     >
-      {options.map((option) => {
+      {options.map((option, index) => {
         const isSelected = value?.index === option.index;
         const setColor = isSelected ? palette.primary.light : palette.background.neutral;
 
         return (
-          <ZSPressable
-            key={option.index}
-            onPress={() => handleSelect(option)}
-            pressedBackgroundColor="transparent"
-            fullWidth
-          >
-            <ViewAtom
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                paddingVertical: 12,
-                borderWidth: 1,
-                paddingLeft: 10,
-                paddingRight: 15,
-                borderRadius: 26,
-                borderColor: setColor,
-                backgroundColor: isSelected ? palette.background.layer1 : 'transparent',
-                flex: 1,
-              }}
+          <ViewAtom key={option.index} style={{ 
+            width: rowCount === 2 
+              ? '50%' 
+              : rowCount === 3 
+                ? '33.33%' 
+                : '100%',
+            paddingHorizontal: 5,
+            paddingBottom: index === options.length - 1 ? 0 : 10,
+          }}>
+            <ZSPressable
+              onPress={() => handleSelect(option)}
+              pressedBackgroundColor="transparent"
+              fullWidth
             >
-              {/* fullWidth가 false일 때 동그라미 체크박스 표시 */}
-              {!fullWidth && (
-                <ViewAtom
-                  style={{
-                    width: 20,
-                    height: 20,
-                    borderWidth: 1,
-                    borderRadius: 10,
-                    borderColor: setColor,
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                  }}
-                >
+              <ViewAtom
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  paddingVertical: 12,
+                  borderWidth: 1,
+                  paddingLeft: 10,
+                  paddingRight: 15,
+                  borderRadius: 26,
+                  borderColor: setColor,
+                  backgroundColor: isSelected ? palette.background.layer1 : 'transparent',
+                }}
+              >
+                {/* fullWidth가 false일 때 동그라미 체크박스 표시 */}
+                {!fullWidth && (
                   <ViewAtom
                     style={{
-                      width: 12,
-                      height: 12,
-                      borderRadius: 6,
-                      backgroundColor: setColor,
-                    }}
-                  />
-                </ViewAtom>
-              )}
-              {/* 옵션 텍스트 표시 */}
-              <ZSText style={{ marginLeft: 10 }} {...valueStyle}>
-                {option.value}
-              </ZSText>
-
-              {/* fullWidth가 true일 때 우측에 선택 버튼 표시 */}
-              {fullWidth && (
-                <ViewAtom style={{ flex: 1, flexDirection: 'row', justifyContent: 'flex-end' }}>
-                  <ViewAtom
-                    style={{
-                      backgroundColor: isSelected
-                        ? palette.primary.main
-                        : palette.background.layer2,
-                      paddingHorizontal: 10,
-                      borderRadius: 50,
-                      minWidth: 42,
-                      minHeight: 24,
+                      width: 20,
+                      height: 20,
+                      borderWidth: 1,
+                      borderRadius: 10,
+                      borderColor: setColor,
                       justifyContent: 'center',
                       alignItems: 'center',
                     }}
                   >
-                    {isSelected ? (
-                      <SvgCheck size={18} />
-                    ) : (
-                      <ZSText typo="body.5" {...selectStyle}>
-                        선택
-                      </ZSText>
-                    )}
+                    <ViewAtom
+                      style={{
+                        width: 12,
+                        height: 12,
+                        borderRadius: 6,
+                        backgroundColor: setColor,
+                      }}
+                    />
                   </ViewAtom>
-                </ViewAtom>
-              )}
-            </ViewAtom>
-          </ZSPressable>
+                )}
+                {/* 옵션 텍스트 표시 */}
+                <ZSText style={{ paddingHorizontal: 10 }} {...valueStyle}>
+                  {option.value}
+                </ZSText>
+
+                {/* fullWidth가 true일 때 우측에 선택 버튼 표시 */}
+                {fullWidth && (
+                  <ViewAtom style={{ flex: 1, flexDirection: 'row', justifyContent: 'flex-end' }}>
+                    <ViewAtom
+                      style={{
+                        backgroundColor: isSelected
+                          ? palette.primary.main
+                          : palette.background.layer2,
+                        paddingHorizontal: 10,
+                        borderRadius: 50,
+                        minWidth: 42,
+                        minHeight: 24,
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                      }}
+                    >
+                      {isSelected ? (
+                        <SvgCheck size={18} />
+                      ) : (
+                        <ZSText typo="body.5" {...selectStyle}>
+                          선택
+                        </ZSText>
+                      )}
+                    </ViewAtom>
+                  </ViewAtom>
+                )}
+              </ViewAtom>
+            </ZSPressable>
+          </ViewAtom>
         );
       })}
     </ViewAtom>


### PR DESCRIPTION
## Sourcery 요약

새로운 rowCount prop을 통해 ZSRadioGroup에서 그리드 레이아웃을 활성화하고, 내부 레이아웃 및 간격을 리팩터링하고, 그리드를 보여주도록 예제를 업데이트하고, 버전을 0.3.3으로 올립니다.

새로운 기능:
- ZSRadioGroup에 rowCount prop을 추가하여 2열 또는 3열 그리드 레이아웃을 지정합니다.

개선 사항:
- 그리드 배열을 위해 동적 너비와 마진을 계산하도록 ZSRadioGroup 항목 래핑 및 간격을 리팩터링합니다.
- 전체 너비 및 그리드 모드 모두에 대해 표시기 원 크기 및 전체 스타일을 조정합니다.

문서:
- LayoutExample에 ZSRadioGroup에 대한 새로운 그리드 레이아웃 예제를 추가합니다.

잡일:
- 패키지 버전을 0.3.3으로 올립니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable grid layout in ZSRadioGroup via a new rowCount prop, refactor its internal layout and spacing, update the example to showcase the grid, and bump version to 0.3.3.

New Features:
- Add rowCount prop to ZSRadioGroup to specify two- or three-column grid layouts.

Enhancements:
- Refactor ZSRadioGroup item wrapping and spacing to calculate dynamic widths and margin for grid arrangement.
- Adjust indicator circle dimensions and overall styling for both full-width and grid modes.

Documentation:
- Add a new grid layout example for ZSRadioGroup in LayoutExample.

Chores:
- Bump package version to 0.3.3.

</details>