### PR TITLE
0.5.1

### DIFF
--- a/example/app/LayoutExample.tsx
+++ b/example/app/LayoutExample.tsx
@@ -155,7 +155,6 @@ function LayoutExample(): React.JSX.Element {
           ]}
           value={responseType}
           onSelect={setResponseType}
-          fullWidth
         />
       </TitleCard>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/ui/ZSRadioGroup/index.tsx
+++ b/src/ui/ZSRadioGroup/index.tsx
@@ -14,9 +14,8 @@ function ZSRadioGroup({
   containerStyle,
   valueStyle,
   disabled = false,
-  fullWidth = false,
   selectStyle,
-  rowCount,
+  rowCount = 1,
 }: {
   options: RadioOption[];
   value?: RadioOption;
@@ -25,10 +24,10 @@ function ZSRadioGroup({
   valueStyle?: ZSTextProps;
   selectStyle?: ZSTextProps;
   disabled?: boolean;
-  fullWidth?: boolean;
-  rowCount?: 2 | 3;
+  rowCount?: 1 | 2 | 3;
 }) {
   const { palette } = useTheme();
+  const isFullWidth = rowCount === 1;
 
   const handleSelect = useCallback((option: RadioOption) => {
     if (!disabled) {
@@ -39,8 +38,8 @@ function ZSRadioGroup({
   return (
     <ViewAtom
       style={{
-        flexDirection: fullWidth ? 'column' : 'row',
-        flexWrap: fullWidth ? 'nowrap' : 'wrap',
+        flexDirection: isFullWidth ? 'column' : 'row',
+        flexWrap: isFullWidth ? 'nowrap' : 'wrap',
         width: '100%',
       }}
       {...containerStyle}
@@ -49,15 +48,20 @@ function ZSRadioGroup({
         const isSelected = value?.index === option.index;
         const setColor = isSelected ? palette.primary.light : palette.background.neutral;
 
+        const colCount = rowCount;
+        const isLastCol = (index + 1) % colCount === 0;
+        const isLastRow = Math.ceil((index + 1) / colCount) === Math.ceil(options.length / colCount);
+
         return (
-          <ViewAtom key={option.index} style={{ 
-            width: rowCount === 2 
-              ? '50%' 
-              : rowCount === 3 
-                ? '33.33%' 
+          <ViewAtom key={option.index} style={{
+            width: rowCount === 2
+              ? '50%'
+              : rowCount === 3
+                ? '33.33%'
                 : '100%',
-            paddingHorizontal: 5,
-            paddingBottom: index === options.length - 1 ? 0 : 10,
+            paddingRight: isFullWidth ? 0 : isLastCol ? 0 : 3,
+            paddingLeft: isFullWidth ? 0 : isLastCol ? 3 : 0,
+            paddingBottom: isLastRow ? 0 : 10,
           }}>
             <ZSPressable
               onPress={() => handleSelect(option)}
@@ -72,13 +76,13 @@ function ZSRadioGroup({
                   borderWidth: 1,
                   paddingLeft: 10,
                   paddingRight: 15,
-                  borderRadius: 26,
+                  borderRadius: 100,
                   borderColor: setColor,
                   backgroundColor: isSelected ? palette.background.layer1 : 'transparent',
                 }}
               >
                 {/* fullWidth가 false일 때 동그라미 체크박스 표시 */}
-                {!fullWidth && (
+                {!(isFullWidth) && (
                   <ViewAtom
                     style={{
                       width: 20,
@@ -101,12 +105,12 @@ function ZSRadioGroup({
                   </ViewAtom>
                 )}
                 {/* 옵션 텍스트 표시 */}
-                <ZSText style={{ paddingHorizontal: 10 }} {...valueStyle}>
+                <ZSText style={{ paddingLeft: 10, paddingRight: 12 }} {...valueStyle}>
                   {option.value}
                 </ZSText>
 
                 {/* fullWidth가 true일 때 우측에 선택 버튼 표시 */}
-                {fullWidth && (
+                {isFullWidth && (
                   <ViewAtom style={{ flex: 1, flexDirection: 'row', justifyContent: 'flex-end' }}>
                     <ViewAtom
                       style={{
@@ -114,7 +118,7 @@ function ZSRadioGroup({
                           ? palette.primary.main
                           : palette.background.layer2,
                         paddingHorizontal: 10,
-                        borderRadius: 50,
+                        borderRadius: 100,
                         minWidth: 42,
                         minHeight: 24,
                         justifyContent: 'center',


### PR DESCRIPTION
## Sourcery 요약

ZSRadioGroup을 리팩터링하여 `fullWidth` prop을 `rowCount` 기반 레이아웃으로 대체하고, 기본적으로 단일 열 표시로 설정하며, 항목 간격 및 스타일을 그에 따라 조정합니다.

개선 사항:
- `fullWidth` 불리언을 `rowCount` prop으로 대체하고, 기본값은 1로 설정하며 `isFullWidth`는 이를 통해 파생합니다.
- 계산된 행 및 열 위치를 기반으로 다중 열 레이아웃을 위한 동적 패딩 로직을 추가합니다.
- `borderRadius` 값을 표준화하고 라디오 옵션의 텍스트 패딩을 조정합니다.

빌드:
- 패키지 버전을 `0.5.1`로 올립니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor ZSRadioGroup to replace the fullWidth prop with a rowCount-driven layout, default to a single-column display, and adjust item spacing and styling accordingly

Enhancements:
- Replace fullWidth boolean with rowCount prop defaulting to 1 and derive isFullWidth from it
- Add dynamic padding logic for multi-column layouts based on calculated row and column positions
- Standardize borderRadius values and adjust text padding for radio options

Build:
- Bump package version to 0.5.1

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the layout and styling of the radio group component by consolidating layout control under a single prop and enhancing spacing and rounded corners for a more consistent appearance.
* **Chores**
  * Updated the application version to 0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->