### PR TITLE
0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "module",

--- a/src/model/useStyleSheetCreate.ts
+++ b/src/model/useStyleSheetCreate.ts
@@ -2,7 +2,9 @@ import { useMemo } from "react";
 import { Theme } from "../theme/types";
 import { useTheme } from "./useThemeProvider";
 
-export const useStyleSheetCreate = (createStyles: (palette: Theme) => any) => {
+export const useStyleSheetCreate = <T extends Record<string, any>>(
+  createStyles: (palette: Theme) => T
+): T => {
   const { palette } = useTheme();
   return useMemo(() => createStyles(palette), [palette]);
 };

--- a/src/ui/ZSTextField/index.tsx
+++ b/src/ui/ZSTextField/index.tsx
@@ -88,7 +88,7 @@ function ZSTextField({
     const labelFontSize = interpolate(
       labelAnimationValue.value,
       [0, 1],
-      [fontSize + (boxStyle === 'inbox' ? 2 : 0), boxStyle === 'inbox' ? 11 : 12],
+      [fontSize + (boxStyle === 'inbox' ? 1 : 0), boxStyle === 'inbox' ? 10 : 11],
       'clamp'
     );
 
@@ -97,7 +97,7 @@ function ZSTextField({
       [0, 1],
       [
         isTextArea ? 12 : 0,
-        isTextArea ? -12 : -(boxHeightValue.value / 2) - 1 + (boxStyle === 'inbox' ? 17 : 0),
+        isTextArea ? -12 : -(boxHeightValue.value / 2) - 1 + (boxStyle === 'inbox' ? 17 : 2),
       ],
       'clamp'
     );


### PR DESCRIPTION
## Sourcery 요약

스타일 시트 생성의 타입 안정성을 개선하고, ZSTextField에서 레이블 애니메이션 오프셋을 조정하며, 패키지 버전을 0.5.2로 업데이트합니다.

버그 수정:
- 인박스 및 텍스트 영역 모드에서 ZSTextField 레이블 애니메이션의 보간 값을 조정합니다.

개선 사항:
- 더 강력한 스타일 시트 타입 지정을 위해 useStyleSheetCreate에 제네릭 반환 타입을 추가합니다.

빌드:
- 패키지 버전을 0.5.1에서 0.5.2로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve type safety for style sheet creation, adjust label animation offsets in ZSTextField, and bump package version to 0.5.2.

Bug Fixes:
- Adjust interpolation values for ZSTextField label animations in inbox and text area modes.

Enhancements:
- Add generic return type to useStyleSheetCreate for stronger style sheet typing.

Build:
- Update package version from 0.5.1 to 0.5.2.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined label font size and positioning in text fields for improved visual consistency.

* **Refactor**
  * Enhanced type safety in the style sheet creation hook for more reliable usage.

* **Chores**
  * Updated version number to 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->