### PR TITLE
0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,21 @@ ZS-ui는 JavaScript만으로 구현된 Expo용 UI 컴포넌트 라이브러리�
 
 <br />
 
-### 설치
+## 설치
 
 ```bash
-npx expo install @react-native-async-storage/async-storage react-native-reanimated react-native-svg react-native-safe-area-context
-
 npx expo install @0610studio/zs-ui
 ```
 
 <br />
 
-### 사용법
+## 사용법
 
 사용법은 [문서](https://0610studio.github.io/zs-ui/docs/intro)를 확인해주세요.
 
 <br />
 
-### TODO
+## TODO
 
 - [ ] 폴더블 폰에서 접힘/펼침 상태 변경으로 인해 액티비티가 재시작되었을 때, `Dimensions.get('window')`가 이전 값을 반환하고 onChange가 호출되지 않는 문제
 

--- a/example/app/ZSContainerExample.tsx
+++ b/example/app/ZSContainerExample.tsx
@@ -1,0 +1,56 @@
+import { View } from "react-native";
+import { ZSContainer, ZSTextField } from "zs-ui";
+import AboveKeyboard from "../src/ui/AboveKeyboard";
+import CtaButton from "../src/ui/CtaButton";
+
+function ZSContainerExample() {
+  return (
+    <ZSContainer
+      edges={['bottom']}
+      keyboardScrollExtraOffset={130}
+      style={{ padding: 30 }}
+      bottomComponent={
+        <AboveKeyboard
+          render={() => (
+            <CtaButton
+              primaryButtonText='수정하기'
+              onPrimaryButtonPress={() => { }}
+            />
+          )}
+        />
+      }
+    >
+      <ZSTextField
+        boxStyle="outline"
+        label="필드 1"
+        value={''}
+        onChangeText={() => { }}
+        focusColor={'red'}
+      />
+
+      <View style={{ height: 500 }} />
+
+      <ZSTextField
+        boxStyle="underline"
+        label="필드 2"
+        value={''}
+        onChangeText={() => { }}
+        focusColor={'red'}
+      />
+
+      <View style={{ height: 500 }} />
+
+      <ZSTextField
+        boxStyle="outline"
+        label="필드 3"
+        value={''}
+        onChangeText={() => { }}
+        focusColor={'red'}
+      />
+
+      <View style={{ height: 100 }} />
+    </ZSContainer>
+  );
+}
+
+export default ZSContainerExample;

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -20,6 +20,7 @@ export default function Home() {
       <Button title='Theme 예제' onPress={() => router.push('/ThemeExample')} />
       <Button title='Layout 예제' onPress={() => router.push('/LayoutExample')} />
       <Button title='Overlay 예제' onPress={() => router.push('/OverlayExample')} />
+      <Button title='ZSContainer 예제' onPress={() => router.push('/ZSContainerExample')} />
     </ZSContainer>
   );
 }

--- a/example/src/ui/AboveKeyboard.tsx
+++ b/example/src/ui/AboveKeyboard.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { Keyboard, Platform, StyleSheet } from 'react-native';
+import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface Props {
+  render: () => React.ReactNode;
+  offset?: number;
+}
+
+function AboveKeyboard({
+  render,
+  offset = 0,
+}: Props) {
+  const [bottomValue, setBottomValue] = useState(0);
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+  const { bottom } = useSafeAreaInsets();
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const keyboardShowSubscription = Keyboard.addListener(showEvent, (event) => {
+      setBottomValue(Platform.OS === 'ios' ? event.endCoordinates.height - bottom : 0);
+      setIsKeyboardVisible(true);
+    });
+
+    const keyboardHideSubscription = Keyboard.addListener(hideEvent, () => {
+      setBottomValue(0);
+      setIsKeyboardVisible(false);
+    });
+
+    return () => {
+      keyboardShowSubscription.remove();
+      keyboardHideSubscription.remove();
+    };
+  }, []);
+
+  return (
+    <Animated.View entering={FadeInDown} exiting={FadeOutDown} style={[styles.container, { bottom: bottomValue + (isKeyboardVisible ? offset : 0) }]}>
+      {render()}
+    </Animated.View>
+  );
+}
+
+export default AboveKeyboard;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 8400,
+    width: '100%',
+  },
+});

--- a/example/src/ui/CtaButton.tsx
+++ b/example/src/ui/CtaButton.tsx
@@ -1,0 +1,135 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { StyleSheet, View } from 'react-native';
+import { useCallback } from 'react';
+import { useStyleSheetCreate, useTheme } from 'zs-ui/model';
+import { Theme, useOverlay, ZSPressable, ZSText } from 'zs-ui';
+
+interface CtaButtonProps {
+  type?: 'single' | 'leftSubTitle' | 'bottomSubTitle';
+  backgroundColor?: string;
+  // ------------------------------
+  primaryButtonText: string;
+  onPrimaryButtonPress: () => void;
+  secondaryButtonText?: string;
+  onSecondaryButtonPress?: () => void;
+  // ------------------------------
+  disabled?: boolean;
+  disabledPressText?: string;
+}
+
+function CtaButton({
+  onPrimaryButtonPress,
+  onSecondaryButtonPress,
+  primaryButtonText,
+  secondaryButtonText,
+  type = 'single',
+  disabled,
+  backgroundColor,
+  disabledPressText,
+}: CtaButtonProps) {
+  const styles = useStyleSheetCreate(createStyles);
+  const { palette } = useTheme();
+  const ctaBackgroundColor = backgroundColor || palette.background.base;
+  const { showSnackBar } = useOverlay();
+
+  const disabledPress = useCallback(() => {
+    if (disabled) {
+      showSnackBar({ type: 'error', message: disabledPressText || '' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [disabled, disabledPressText]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: ctaBackgroundColor }]}>
+      <View style={styles.buttonContainer}>
+        <View style={styles.rowContainer}>
+          {
+            type === 'leftSubTitle' && secondaryButtonText && (
+              <ZSPressable hitSlop={5} style={styles.leftSubButton} onPress={onSecondaryButtonPress}>
+                <ZSText typo='label.1' color='secondary'>{secondaryButtonText}</ZSText>
+              </ZSPressable>
+            )
+          }
+
+          <View style={styles.flex1}>
+            <ZSPressable style={styles.button} onPress={disabled ? disabledPress : onPrimaryButtonPress} color={disabled ? 'grey.30' : 'primary'}>
+              <ZSText typo='subTitle.1' color={disabled ? 'grey.70' : 'white'}>{primaryButtonText}</ZSText>
+            </ZSPressable>
+          </View>
+        </View>
+
+        {
+          type === 'bottomSubTitle' && secondaryButtonText && (
+            <ZSPressable style={styles.bottomSubTitle} onPress={onSecondaryButtonPress}>
+              <ZSText typo='label.1' color='secondary'>{secondaryButtonText}</ZSText>
+            </ZSPressable>
+          )
+        }
+      </View>
+
+      <LinearGradient
+        style={styles.background}
+        colors={['#ffffff00', ctaBackgroundColor]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+      />
+    </View>
+  );
+}
+
+const createStyles = (palette: Theme) => StyleSheet.create({
+  flex1: { flex: 1 },
+  checkBoxTextStyle: { marginTop: -2 },
+  container: { width: '100%', paddingBottom: 10 },
+  rowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    width: '100%',
+  },
+  leftSubButton: {
+    paddingVertical: 16,
+    paddingHorizontal: 28,
+  },
+  buttonContainer: {
+    width: '100%',
+    paddingHorizontal: 16,
+    paddingTop: 15,
+    flexDirection: 'column',
+  },
+  button: {
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 16,
+    borderRadius: 14,
+  },
+  background: {
+    width: '100%',
+    height: 30,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    marginTop: -30,
+  },
+  bottomSubTitle: {
+    paddingVertical: 8,
+    marginTop: 5,
+    paddingHorizontal: 14,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  checkBoxContainer: {
+    paddingVertical: 8,
+    marginTop: 5,
+    paddingHorizontal: 14,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+});
+
+export default CtaButton;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "start:android": "cd example && yarn install && npx expo run:android",
-    "start:ios": "cd example && yarn install && npx expo run:ios",
+    "start:ios": "cd example && yarn install && npx expo run:ios --device",
     "build": "expo-module build",
     "prepare": "expo-module prepare",
     "---------------------------------------------------------------------------": "",

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -104,23 +104,31 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
     >
       <View style={styles.flex1}>
         {topComponent && topComponent}
-        <ScrollView
-          ref={scrollViewRef}
-          style={styles.flex1}
-          contentContainerStyle={[styles.scrollContainerStyle, { paddingBottom: Platform.OS === 'ios' ? keyboardHeight || 0 : 0 }]}
-          bounces={false}
-          overScrollMode="never"
-          showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-          keyboardShouldPersistTaps="handled"
-          automaticallyAdjustKeyboardInsets={false}
-          onScroll={handleScroll}
-          onTouchStart={handleTouch}
-          scrollEventThrottle={scrollEventThrottle}
-        >
-          <View style={[styles.flex1, props.style]}>
-            {props.children}
-          </View>
-        </ScrollView>
+        {
+          scrollViewDisabled ? (
+            <View style={styles.flex1}>
+              {props.children}
+            </View>
+          ) : (
+            <ScrollView
+              ref={scrollViewRef}
+              style={styles.flex1}
+              contentContainerStyle={[styles.scrollContainerStyle, { paddingBottom: Platform.OS === 'ios' ? keyboardHeight || 0 : 0 }]}
+              bounces={false}
+              overScrollMode="never"
+              showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+              keyboardShouldPersistTaps="handled"
+              automaticallyAdjustKeyboardInsets={false}
+              onScroll={handleScroll}
+              onTouchStart={handleTouch}
+              scrollEventThrottle={scrollEventThrottle}
+            >
+              <View style={[styles.flex1, props.style]}>
+                {props.children}
+              </View>
+            </ScrollView>
+          )
+        }
         {bottomComponent && bottomComponent}
       </View>
 

--- a/src/ui/ZSContainer/ui/VariantView.tsx
+++ b/src/ui/ZSContainer/ui/VariantView.tsx
@@ -25,7 +25,7 @@ export default function VariantView({ children, scrollViewDisabled, style, scrol
       <ScrollView
         ref={scrollViewRef}
         style={{ width: variantWidth }}
-        contentContainerStyle={[styles.scrollContainerStyle, { paddingBottom: keyboardHeight || 0 }]}
+        // contentContainerStyle={[styles.scrollContainerStyle, { paddingBottom: keyboardHeight || 0 }]}
         bounces={false}
         overScrollMode="never"
         showsVerticalScrollIndicator={showsVerticalScrollIndicator}
@@ -35,9 +35,9 @@ export default function VariantView({ children, scrollViewDisabled, style, scrol
         onTouchStart={handleTouch}
         scrollEventThrottle={scrollEventThrottle}
       >
-        <View style={[styles.splitView, style, { width: '100%' }]}>
+        {/* <View style={[styles.splitView, style, { width: '100%' }]}>
           {children}
-        </View>
+        </View> */}
       </ScrollView>
     )
   )


### PR DESCRIPTION
## Sourcery 요약

버전을 0.7.0으로 올리고, ZSContainer를 전면 개편하여 더 간단한 레이아웃과 개선된 키보드 동작을 제공합니다. 또한 문서를 업데이트하고 ZSContainer를 위한 예제 컴포넌트와 데모를 추가합니다.

새로운 기능:
- CtaButton 및 AboveKeyboard 컴포넌트 추가 및 예제 앱에 ZSContainerExample 포함

개선 사항:
- ZSContainer 리팩토링: split view 및 loader props 제거, 단일 ScrollView로 단순화, 키보드 처리 간소화
- `scrollEventThrottle` (16) 및 `keyboardScrollExtraOffset` (30)의 기본값 업데이트

빌드:
- 패키지 버전을 0.7.0으로 올리고 `start:ios` 스크립트 수정

문서:
- README 헤딩 및 설치/사용 섹션 조정

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump version to 0.7.0, overhaul ZSContainer for simpler layout and improved keyboard behavior, update documentation, and add example components and a demo for ZSContainer.

New Features:
- Add CtaButton and AboveKeyboard components and include a ZSContainerExample in the example app

Enhancements:
- Refactor ZSContainer to remove split view and loader props, simplify to a single ScrollView, and streamline keyboard handling
- Update default values for scrollEventThrottle (16) and keyboardScrollExtraOffset (30)

Build:
- Bump package version to 0.7.0 and modify the start:ios script

Documentation:
- Adjust README headings and installation/usage sections

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new UI components: `AboveKeyboard` for keyboard-aware layouts and `CtaButton` with versatile button arrangements.
  * Added an example screen showcasing the updated container and button components, accessible from the home screen.

* **Improvements**
  * Simplified the scrollable container by removing split view and loading states for a cleaner layout.

* **Documentation**
  * Updated README with clearer installation instructions and improved heading hierarchy.

* **Chores**
  * Bumped package version to 0.7.1 and enhanced iOS start script to target physical devices explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->