### PR TITLE
0.7.3

### DIFF
--- a/example/app/ZSContainerExample.tsx
+++ b/example/app/ZSContainerExample.tsx
@@ -1,23 +1,15 @@
 import { View } from "react-native";
-import { ZSAboveKeyboard, ZSContainer, ZSTextField } from "zs-ui";
+import { ZSContainer, ZSTextField, ZSAboveKeyboard } from "zs-ui";
 import CtaButton from "../src/ui/CtaButton";
+import { useState } from "react";
 
 function ZSContainerExample() {
+  const [ctaLayoutHeight, setCtaLayoutHeight] = useState(0);
   return (
     <ZSContainer
       edges={['bottom']}
       keyboardScrollExtraOffset={130}
-      style={{ padding: 30 }}
-      bottomComponent={
-        <ZSAboveKeyboard
-          render={() => (
-            <CtaButton
-              primaryButtonText='CTA 버튼'
-              onPrimaryButtonPress={() => { }}
-            />
-          )}
-        />
-      }
+      style={{ paddingHorizontal: 30, paddingTop: 30, paddingBottom: 30 + ctaLayoutHeight }}
     >
       <ZSTextField
         boxStyle="outline"
@@ -47,7 +39,17 @@ function ZSContainerExample() {
         focusColor={'red'}
       />
 
-      <View style={{ height: 100 }} />
+      <ZSAboveKeyboard handleLayoutHeight={setCtaLayoutHeight}>
+        <CtaButton
+          disabled={false}
+          // ---
+          primaryButtonText='CTA 버튼'
+          onPrimaryButtonPress={() => { }}
+          // ---
+          secondaryButtonText='취소'
+          onSecondaryButtonPress={() => { }}
+        />
+      </ZSAboveKeyboard>
     </ZSContainer>
   );
 }

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -20,7 +20,7 @@ export default function Home() {
       <Button title='Theme 예제' onPress={() => router.push('/ThemeExample')} />
       <Button title='Layout 예제' onPress={() => router.push('/LayoutExample')} />
       <Button title='Overlay 예제' onPress={() => router.push('/OverlayExample')} />
-      <Button title='ZSContainer 예제' onPress={() => router.push('/ZSContainerExample')} />
+      <Button title='ZS_Container 예제' onPress={() => router.push('/ZSContainerExample')} />
     </ZSContainer>
   );
 }

--- a/example/src/ui/CtaButton.tsx
+++ b/example/src/ui/CtaButton.tsx
@@ -1,75 +1,65 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { StyleSheet, View } from 'react-native';
-import { useCallback } from 'react';
-import { useStyleSheetCreate, useTheme } from 'zs-ui/model';
-import { Theme, useOverlay, ZSPressable, ZSText } from 'zs-ui';
+import { useTheme, ZSPressable, ZSText } from 'zs-ui';
 
 interface CtaButtonProps {
-  type?: 'single' | 'leftSubTitle' | 'bottomSubTitle';
-  backgroundColor?: string;
-  // ------------------------------
   primaryButtonText: string;
   onPrimaryButtonPress: () => void;
-  secondaryButtonText?: string;
+  disabled: boolean;
+  backgroundColor?: string;
+  bottomComponent?: React.ReactNode;
+  secondaryButtonText: string;
   onSecondaryButtonPress?: () => void;
-  // ------------------------------
-  disabled?: boolean;
-  disabledPressText?: string;
+  onDisabledPress?: () => void;
 }
 
 function CtaButton({
   onPrimaryButtonPress,
-  onSecondaryButtonPress,
   primaryButtonText,
-  secondaryButtonText,
-  type = 'single',
   disabled,
   backgroundColor,
-  disabledPressText,
+  bottomComponent,
+  secondaryButtonText,
+  onSecondaryButtonPress,
+  onDisabledPress,
 }: CtaButtonProps) {
-  const styles = useStyleSheetCreate(createStyles);
   const { palette } = useTheme();
   const ctaBackgroundColor = backgroundColor || palette.background.base;
-  const { showSnackBar } = useOverlay();
-
-  const disabledPress = useCallback(() => {
-    if (disabled) {
-      showSnackBar({ type: 'error', message: disabledPressText || '' });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [disabled, disabledPressText]);
 
   return (
     <View style={[styles.container, { backgroundColor: ctaBackgroundColor }]}>
       <View style={styles.buttonContainer}>
         <View style={styles.rowContainer}>
           {
-            type === 'leftSubTitle' && secondaryButtonText && (
-              <ZSPressable hitSlop={5} style={styles.leftSubButton} onPress={onSecondaryButtonPress}>
+            secondaryButtonText && (
+              <ZSPressable hitSlop={5} style={styles.leftSubButton} onPress={() => { onSecondaryButtonPress?.() }}>
                 <ZSText typo='label.1' color='secondary'>{secondaryButtonText}</ZSText>
               </ZSPressable>
             )
           }
 
           <View style={styles.flex1}>
-            <ZSPressable style={styles.button} onPress={disabled ? disabledPress : onPrimaryButtonPress} color={disabled ? 'grey.30' : 'primary'}>
+            <ZSPressable
+              style={styles.button}
+              color={disabled ? 'grey.30' : 'primary'}
+              onPress={() => {
+                if (disabled) {
+                  onDisabledPress?.();
+                } else {
+                  onPrimaryButtonPress();
+                }
+              }}>
               <ZSText typo='subTitle.1' color={disabled ? 'grey.70' : 'white'}>{primaryButtonText}</ZSText>
             </ZSPressable>
           </View>
         </View>
 
-        {
-          type === 'bottomSubTitle' && secondaryButtonText && (
-            <ZSPressable style={styles.bottomSubTitle} onPress={onSecondaryButtonPress}>
-              <ZSText typo='label.1' color='secondary'>{secondaryButtonText}</ZSText>
-            </ZSPressable>
-          )
-        }
+        {bottomComponent && bottomComponent}
       </View>
 
       <LinearGradient
         style={styles.background}
-        colors={['#ffffff00', ctaBackgroundColor]}
+        colors={[`${ctaBackgroundColor}00`, `${ctaBackgroundColor}dd`, ctaBackgroundColor]}
         start={{ x: 0, y: 0 }}
         end={{ x: 0, y: 1 }}
       />
@@ -77,9 +67,8 @@ function CtaButton({
   );
 }
 
-const createStyles = (palette: Theme) => StyleSheet.create({
+const styles = StyleSheet.create({
   flex1: { flex: 1 },
-  checkBoxTextStyle: { marginTop: -2 },
   container: { width: '100%', paddingBottom: 10 },
   rowContainer: {
     flexDirection: 'row',
@@ -93,9 +82,9 @@ const createStyles = (palette: Theme) => StyleSheet.create({
   },
   buttonContainer: {
     width: '100%',
-    paddingHorizontal: 16,
     paddingTop: 15,
     flexDirection: 'column',
+    paddingHorizontal: 14,
   },
   button: {
     width: '100%',
@@ -106,29 +95,12 @@ const createStyles = (palette: Theme) => StyleSheet.create({
   },
   background: {
     width: '100%',
-    height: 30,
+    height: 20,
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
-    marginTop: -30,
-  },
-  bottomSubTitle: {
-    paddingVertical: 8,
-    marginTop: 5,
-    paddingHorizontal: 14,
-    width: '100%',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  checkBoxContainer: {
-    paddingVertical: 8,
-    marginTop: 5,
-    paddingHorizontal: 14,
-    width: '100%',
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'row',
+    marginTop: -19,
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   useOverlay,
   PopOverButton,
   PopOverMenu,
+  ZSPortal,
 } from './overlay';
 
 export {
@@ -55,6 +56,7 @@ export {
   useOverlay,
   PopOverButton,
   PopOverMenu,
+  ZSPortal,
 };
 
 // ------------------------------------------------------

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -98,7 +98,7 @@ export interface SnackItem {
 
 export type SnackType = 'success' | 'error' | '';
 
-export type HideOption = 'all' | 'snack' | 'alert' | 'bottomSheet' | 'loader' | 'popOver' | 'modal';
+export type HideOption = 'all' | 'snack' | 'alert' | 'bottomSheet' | 'loader' | 'popOver' | 'modal' | 'aboveKeyboard';
 
 export interface ShowSnackBarProps {
     message: string;
@@ -119,4 +119,9 @@ export interface ShowBottomSheetProps {
     headerComponent?: React.ReactNode;
     component: React.ReactNode;
     options?: BottomSheetOptions;
+}
+
+export interface AboveKeyboardOptions {
+    keyboardShowOffset?: number;
+    keyboardHideOffset?: number;
 }

--- a/src/model/useOverlayProvider.tsx
+++ b/src/model/useOverlayProvider.tsx
@@ -8,6 +8,7 @@ import BottomSheetOverlay from '../overlay/BottomSheetOverlay';
 import LoadingNotify from '../overlay/LoadingNotify';
 import PopOverMenu from '../overlay/PopOver/PopOverMenu';
 import Modality from '../overlay/Modality';
+import { PortalProvider } from '../overlay/ZSPortal';
 
 export function OverlayProvider({
   customSnackbar,
@@ -262,43 +263,45 @@ export function OverlayProvider({
             <PopOverContext.Provider value={popOverContextValue}>
               <ModalityContext.Provider value={modalityContextValue}>
                 <LoaderContext.Provider value={loaderContextValue}>
-                  {children}
+                  <PortalProvider>
+                      {children}
 
-                  <Modality modalityComponent={modalityComponent} />
+                      <Modality modalityComponent={modalityComponent} />
 
-                  <BottomSheetOverlay
-                    headerComponent={bottomSheetHeader}
-                    component={bottomSheetComponent}
-                    options={bottomSheetOptions}
-                  />
+                      <BottomSheetOverlay
+                        headerComponent={bottomSheetHeader}
+                        component={bottomSheetComponent}
+                        options={bottomSheetOptions}
+                      />
 
-                  <PopOverMenu
-                    px={popOverLocation?.px}
-                    py={popOverLocation?.py}
-                    component={popOverComponent}
-                  />
+                      <PopOverMenu
+                        px={popOverLocation?.px}
+                        py={popOverLocation?.py}
+                        component={popOverComponent}
+                      />
 
-                  <AlertOverlay
-                    title={title}
-                    informative={informative}
-                    actions={actions || {} as AlertActions}
-                    isBackgroundTouchClose={isBackgroundTouchClose}
-                    titleStyle={titleStyle}
-                    informativeStyle={informativeStyle}
-                    secondaryButtonStyle={secondaryButtonStyle}
-                    primaryButtonStyle={primaryButtonStyle}
-                    secondaryButtonTextStyle={secondaryButtonTextStyle}
-                    primaryButtonTextStyle={primaryButtonTextStyle}
-                    singleButtonTextStyle={singleButtonTextStyle}
-                  />
+                      <AlertOverlay
+                        title={title}
+                        informative={informative}
+                        actions={actions || {} as AlertActions}
+                        isBackgroundTouchClose={isBackgroundTouchClose}
+                        titleStyle={titleStyle}
+                        informativeStyle={informativeStyle}
+                        secondaryButtonStyle={secondaryButtonStyle}
+                        primaryButtonStyle={primaryButtonStyle}
+                        secondaryButtonTextStyle={secondaryButtonTextStyle}
+                        primaryButtonTextStyle={primaryButtonTextStyle}
+                        singleButtonTextStyle={singleButtonTextStyle}
+                      />
 
-                  <SnackbarNotify
-                    customSnackbar={customSnackbar}
-                  />
+                      <SnackbarNotify
+                        customSnackbar={customSnackbar}
+                      />
 
-                  <LoadingNotify
-                    loaderComponent={loaderComponent}
-                  />
+                      <LoadingNotify
+                        loaderComponent={loaderComponent}
+                      />
+                  </PortalProvider>
                 </LoaderContext.Provider>
               </ModalityContext.Provider>
             </PopOverContext.Provider>

--- a/src/model/utils.ts
+++ b/src/model/utils.ts
@@ -14,14 +14,6 @@ export const extractStyle = (
     return undefined;
 };
 
-export const getActualTopInset = () => {
-    const { top } = initialWindowMetrics?.insets || { top: 0 };
-    if (Platform.OS === 'ios') {
-      return 0;
-    }
-    return StatusBar.currentHeight || top || 0;
-  };
-
 export const Z_INDEX_VALUE = {
     DEFAULT: 8000,
     MODAL1: 8001,

--- a/src/overlay/ZSPortal/index.tsx
+++ b/src/overlay/ZSPortal/index.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
+import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+
+interface PortalContextType {
+  registerPortal: (id: string, element: ReactNode) => void;
+  unregisterPortal: (id: string) => void;
+}
+
+const PortalContext = createContext<PortalContextType | null>(null);
+
+interface PortalProviderProps {
+  children: ReactNode;
+}
+
+export const PortalProvider: React.FC<PortalProviderProps> = ({ children }) => {
+  const [portals, setPortals] = useState<Map<string, ReactNode>>(new Map());
+
+  const registerPortal = useCallback((id: string, element: ReactNode) => {
+    setPortals(prev => {
+      // 동일한 요소가 이미 등록되어 있다면 업데이트하지 않음
+      if (prev.get(id) === element) {
+        return prev;
+      }
+      const newMap = new Map(prev);
+      newMap.set(id, element);
+      return newMap;
+    });
+  }, []);
+
+  const unregisterPortal = useCallback((id: string) => {
+    setPortals(prev => {
+      // 해당 ID가 존재하지 않으면 상태를 변경하지 않음
+      if (!prev.has(id)) {
+        return prev;
+      }
+      const newMap = new Map(prev);
+      newMap.delete(id);
+      return newMap;
+    });
+  }, []);
+
+  return (
+    <PortalContext.Provider value={{ registerPortal, unregisterPortal }}>
+      {children}
+      {Array.from(portals.entries()).map(([id, element]) => (
+        <Animated.View entering={FadeInDown} exiting={FadeOutDown} key={id} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, pointerEvents: 'box-none' }}>
+          {element}
+        </Animated.View>
+      ))}
+    </PortalContext.Provider>
+  );
+};
+
+// ------------------------------------------------------------------------------------------------
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+export const ZSPortal: React.FC<PortalProps> = ({ children }) => {
+  const context = useContext(PortalContext);
+  const [portalId] = useState(() => `portal_${Date.now()}_${Math.random()}`);
+
+  useEffect(() => {
+    if (context) {
+      context.registerPortal(portalId, children);
+      return () => {
+        context.unregisterPortal(portalId);
+      };
+    }
+    return () => {};
+  }, [children]);
+
+  return null;
+};

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -5,6 +5,7 @@ import * as useOverlayProvider from '../model/useOverlayProvider';
 import { useOverlay } from '../model/useOverlay';
 import PopOverButton from './PopOver/PopOverButton';
 import PopOverMenu from './PopOver/PopOverMenu';
+import { ZSPortal } from './ZSPortal';
 import * as types from '../model/types';
 
 export {
@@ -15,5 +16,6 @@ export {
   useOverlay,
   PopOverButton,
   PopOverMenu,
+  ZSPortal,
   types,
 }


### PR DESCRIPTION
## Sourcery 요약

포털 지원 추가, 핵심 UI 컴포넌트(CtaButton 및 ZSAboveKeyboard)에 새 props 및 리팩토링된 동작으로 개선, 더 이상 사용되지 않는 유틸리티 제거, 그리고 버전을 0.7.3으로 업데이트

새로운 기능:
- 포털을 통해 오버레이를 렌더링하기 위한 ZSPortal 컴포넌트 및 PortalProvider 컨텍스트 도입
- CtaButton에 bottomComponent prop을 허용하도록 확장하고, 항상 왼쪽 보조 버튼을 표시하며, 비활성화 시 onDisabledPress 콜백을 호출하도록 함
- ZSAboveKeyboard에 keyboardShowOffset, keyboardHideOffset props 및 handleLayoutHeight 콜백을 추가하여 사용자 정의 가능한 키보드 인식 위치 지정을 지원

개선 사항:
- useOverlayProvider를 리팩토링하여 모든 오버레이를 PortalProvider로 래핑하고 레거시 getActualTopInset 유틸리티 제거
- type variants, useGradient stops, 및 인라인 스타일 생성을 제거하여 CtaButton 코드 간소화
- ZSAboveKeyboard를 리팩토링하여 애니메이션 뷰를 ZSPortal로 대체하고 수동 인셋 계산 대신 안전 영역 인셋 사용

빌드:
- 패키지 버전을 0.7.3으로 업데이트

문서:
- ZSPortal을 공개 API에 노출하고 사용법을 보여주는 예제 업데이트

기타 작업:
- ZSContainerExample을 업데이트하여 새로운 ZSAboveKeyboard API를 사용하고 동적 패딩을 위한 레이아웃 높이 보고

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add portal support, enhance core UI components (CtaButton and ZSAboveKeyboard) with new props and refactored behavior, remove obsolete utilities, and bump version to 0.7.3

New Features:
- Introduce ZSPortal component and PortalProvider context to render overlays via portals
- Extend CtaButton to accept a bottomComponent prop, always show a left secondary button, and invoke an onDisabledPress callback when disabled
- Add keyboardShowOffset, keyboardHideOffset props and handleLayoutHeight callback to ZSAboveKeyboard for customizable keyboard-aware positioning

Enhancements:
- Refactor useOverlayProvider to wrap all overlays in PortalProvider and remove the legacy getActualTopInset util
- Simplify CtaButton code by removing type variants, useGradient stops, and inline style creation
- Refactor ZSAboveKeyboard to replace animated view with ZSPortal and use safe-area insets instead of manual insets calculation

Build:
- Bump package version to 0.7.3

Documentation:
- Expose ZSPortal in the public API and update examples to demonstrate its usage

Chores:
- Update ZSContainerExample to use the new ZSAboveKeyboard API and report layout height for dynamic padding

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Portal API (ZSPortal) for rendering overlay content.
  - Enhanced above-keyboard UI with explicit keyboard show/hide offsets and optional height callback.
  - Expanded hide options to include “aboveKeyboard” with configurable offsets.
- Refactor
  - Overlay rendering now runs through the portal system.
  - Example app: CTA moved above keyboard with primary/secondary actions; minor label text tweak.
- Changes
  - CtaButton API updated: requires secondary button text and disabled state; supports onDisabledPress and an optional bottom area component.
- Chores
  - Version bumped to 0.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->