### PR TITLE
0.8.1

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -49,6 +49,23 @@
           ]
         }
       ],
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "newArchEnabled": true,
+            "useFrameworks": "static"
+          },
+          "android": {
+            "compileSdkVersion": 35,
+            "targetSdkVersion": 35,
+            "buildToolsVersion": "35.0.0",
+            "kotlinVersion": "1.9.25",
+            "newArchEnabled": true,
+            "usesCleartextTraffic": true
+          }
+        }
+      ]
     ],
     "scheme": "zs-ui-example"
   }

--- a/example/package.json
+++ b/example/package.json
@@ -12,6 +12,7 @@
     "@react-native-async-storage/async-storage": "1.23.1",
     "expo": "52.0.46",
     "expo-blur": "~14.0.3",
+    "expo-build-properties": "~0.13.3",
     "expo-constants": "~17.0.8",
     "expo-linear-gradient": "~14.0.2",
     "expo-linking": "~7.0.5",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1766,7 +1766,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^8.0.0, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.11.0, ajv@^8.9.0:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -2849,6 +2849,14 @@ expo-blur@~14.0.3:
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-14.0.3.tgz#656d6b2442bfbbfb2a6608c6bc1151b29bce6698"
   integrity sha512-BL3xnqBJbYm3Hg9t/HjNjdeY7N/q8eK5tsLYxswWG1yElISWZmMvrXYekl7XaVCPfyFyz8vQeaxd7q74ZY3Wrw==
+
+expo-build-properties@~0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/expo-build-properties/-/expo-build-properties-0.13.3.tgz#6b96d0486148fca6e74e62c7c502c0a9990931aa"
+  integrity sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg==
+  dependencies:
+    ajv "^8.11.0"
+    semver "^7.6.0"
 
 expo-constants@~17.0.5, expo-constants@~17.0.8:
   version "17.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.7.8",
+  "version": "0.8.1",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",

--- a/src/ui/ZSAboveKeyboard/index.tsx
+++ b/src/ui/ZSAboveKeyboard/index.tsx
@@ -29,7 +29,7 @@ function ZSAboveKeyboard({
   useEffect(() => {
     const keyboardShowSubscription = Keyboard.addListener(showEvent, (event) => {
       // 키보드 바로 위에 위치하도록 계산
-      const topValue = screenHeight - event.endCoordinates.height - componentHeight - keyboardShowOffset;
+      const topValue = screenHeight - event.endCoordinates.height - componentHeight - keyboardShowOffset - (Platform.OS === 'android' ? 13 : 0);
       setTopValue(topValue);
       setIsKeyboardVisible(true);
     });

--- a/src/ui/ZSContainer/index.tsx
+++ b/src/ui/ZSContainer/index.tsx
@@ -112,7 +112,7 @@ const ZSContainer = forwardRef<ZSContainerRef, ZSContainerProps>(function ZSCont
   const scrollContentStyle = useMemo(() => [
     styles.scrollContainerStyle, 
     { 
-      paddingBottom: keyboardHeight ? (IS_IOS ? keyboardHeight : 0) : 0 
+      paddingBottom: keyboardHeight ? keyboardHeight : 0 
     }
   ], [keyboardHeight]);
 


### PR DESCRIPTION
## Sourcery 요약

새로운 아키텍처와 최신 SDK 버전을 활성화하도록 예제 빌드 속성을 업데이트하고, 패키지 버전을 범프하며, 핵심 UI 컴포넌트의 키보드 오버레이 및 패딩 문제를 수정하여 v0.8.1 릴리스를 준비합니다.

버그 수정:
- 플랫폼별 Android 오프셋을 추가하여 ZSAboveKeyboard의 키보드 위치를 수정합니다.
- ZSContainer 패딩이 항상 키보드 높이를 고려하도록 조정합니다.

개선 사항:
- 패키지 버전을 0.8.1로 범프합니다.
- 예제에 iOS 및 Android용 새로운 아키텍처 및 SDK 설정을 포함한 expo-build-properties 플러그인을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare v0.8.1 release by updating example build properties to enable new architecture and modern SDK versions, bumping the package version, and fixing keyboard overlay and padding issues in core UI components

Bug Fixes:
- Fix keyboard positioning in ZSAboveKeyboard by adding a platform-specific Android offset
- Adjust ZSContainer padding to always account for keyboard height

Enhancements:
- Bump package version to 0.8.1
- Add expo-build-properties plugin with new architecture and SDK settings for iOS and Android in example

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved above-keyboard component positioning on Android to reduce overlap when the keyboard appears.
  - Unified content bottom padding to honor keyboard height on both iOS and Android for consistent insets.

- Chores
  - Updated example app build settings (new architecture enabled, Android SDK 35, updated build tools/Kotlin, cleartext traffic allowed).
  - Added expo-build-properties to the example app dependencies.
  - Bumped package version to 0.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->