### PR TITLE
0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.8.4",
+  "version": "0.8.6",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",

--- a/src/overlay/BottomSheetOverlay/index.tsx
+++ b/src/overlay/BottomSheetOverlay/index.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { StyleSheet, View, PanResponder, Keyboard, Platform } from 'react-native';
 import { useBottomSheet } from '../../model/useOverlay';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming, runOnJS } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
 import ModalBackground from '../ui/ModalBackground';
 import { useTheme } from '../../model';
 import { useSafeAreaInsets, initialWindowMetrics } from 'react-native-safe-area-context';
@@ -79,7 +79,6 @@ function BottomSheetOverlay({
   const [localVisible, setLocalVisible] = useState(false);
 
   const handleKeyboardShow = useCallback((event: any) => {
-    'worklet';
     if (!isGesturing.value) {
       const targetY = IS_IOS ? (-event.endCoordinates.height + bottom) : 0;
       translateY.value = withTiming(targetY, ANIMATION_CONFIG.keyboard.show);
@@ -87,7 +86,6 @@ function BottomSheetOverlay({
   }, [translateY, bottom, isGesturing]);
 
   const handleKeyboardHide = useCallback(() => {
-    'worklet';
     if (!isGesturing.value) {
       translateY.value = withTiming(0, ANIMATION_CONFIG.keyboard.hide);
     }
@@ -137,8 +135,7 @@ function BottomSheetOverlay({
   }, [setBottomSheetVisible]);
 
   const handlePanResponderGrant = useCallback(() => {
-    'worklet';
-    runOnJS(dismissKeyboard)();
+    dismissKeyboard();
     isGesturing.value = true;
     startX.value = translateX.value;
     startY.value = translateY.value;
@@ -146,7 +143,6 @@ function BottomSheetOverlay({
   }, [translateX, translateY, scale, startX, startY, isGesturing, dismissKeyboard]);
 
   const handlePanResponderMove = useCallback((_, gestureState) => {
-    'worklet';
     const newTranslateX = (startX.value + gestureState.dx) / GESTURE_CONSTANTS.horizontalDamping;
     translateX.value = newTranslateX;
 
@@ -159,7 +155,6 @@ function BottomSheetOverlay({
   }, [translateX, translateY, startX, startY]);
 
   const handlePanResponderRelease = useCallback((_, gestureState) => {
-    'worklet';
     isGesturing.value = false;
     translateX.value = withTiming(0, { duration: 100 });
 
@@ -169,7 +164,7 @@ function BottomSheetOverlay({
     
     if (shouldClose) {
       translateY.value = withTiming(maxHeight + 100, ANIMATION_CONFIG.close);
-      runOnJS(closeBottomSheet)();
+      closeBottomSheet();
     } else {
       translateY.value = withTiming(0, ANIMATION_CONFIG.close);
     }

--- a/src/ui/ZSPressable/index.tsx
+++ b/src/ui/ZSPressable/index.tsx
@@ -46,12 +46,10 @@ function ZSPressable({
   }, []);
   
   const handlePressIn = () => {
-    'worklet';
     isButtonPress.value = withTiming(1, DEFAULT_DURATION);
   };
   
   const handlePressOut = () => {
-    'worklet';
     isButtonPress.value = withTiming(0, DEFAULT_DURATION);
   };
 

--- a/src/ui/ZSText/index.tsx
+++ b/src/ui/ZSText/index.tsx
@@ -1,4 +1,3 @@
-import React, { memo } from 'react';
 import { TextProps } from "react-native/types";
 import { useTheme } from "../../model/useThemeProvider";
 import { TypoOptions, TypoStyle, TypoColorOptions, TypoSubStyle, TypoColor, SubColorOptions } from "../../theme/types";
@@ -20,4 +19,4 @@ function ZSText({
     return <TextAtom {...props} style={[typography[s01][s02], { color: c02 ? palette[c01][c02] : palette.text[c01] }, props.style]}>{props.children}</TextAtom>
 }
 
-export default memo(ZSText);
+export default ZSText;

--- a/src/ui/ZSView/index.tsx
+++ b/src/ui/ZSView/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { ViewProps, StyleSheet } from 'react-native';
 import { useTheme } from '../../model/useThemeProvider';
 import AnimatedWrapper from '../atoms/AnimatedWrapper';
@@ -31,4 +31,4 @@ const ZSView: React.FC<Props> = ({ isAnimation = false, elevationLevel = 0, styl
   );
 };
 
-export default memo(ZSView);
+export default ZSView;


### PR DESCRIPTION
## Sourcery 요약

여러 컴포넌트 전반의 애니메이션 및 스타일 로직을 간소화하고, 오래된 메모이제이션 및 워크릿 상용구를 제거하며, 패키지 버전을 0.8.6으로 업데이트합니다.

개선 사항:
- useDerivedValue 워크릿을 sharedValues 및 단일 useEffect로 대체하여 ZSTextField 애니메이션 로직을 간소화합니다.
- 컴포넌트를 직접 내보내기 위해 ZSTextField, ZSText, ZSView에서 React.memo 래퍼를 제거합니다.
- AnimatedWrapper가 정적 그림자 구성을 위해 useMemo를 사용하도록 리팩터링하고 스타일 배열을 정리합니다.
- BottomSheetOverlay 및 ZSPressable에서 중복된 워크릿 어노테이션 및 runOnUI 호출을 제거합니다.
- 배열을 인라인하고 불필요한 useMemo 및 useCallback 훅을 제거하여 스타일 및 콜백 정의를 간소화합니다.

빌드:
- 패키지 버전을 0.8.6으로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify animation and style logic across multiple components, remove outdated memoization and worklet boilerplate, and bump package version to 0.8.6

Enhancements:
- Simplify ZSTextField animation logic by replacing useDerivedValue worklets with sharedValues and a single useEffect
- Remove React.memo wrappers from ZSTextField, ZSText, and ZSView to export components directly
- Refactor AnimatedWrapper to use useMemo for static shadow configuration and clean up style arrays
- Eliminate redundant worklet annotations and runOnUI calls in BottomSheetOverlay and ZSPressable
- Streamline style and callback definitions by inlining arrays and removing unnecessary useMemo and useCallback hooks

Build:
- Bump package version to 0.8.6

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved responsiveness of the bottom sheet and pressable interactions for smoother gestures.
  * Simplified text field focus, error, and label animations for clearer, more consistent feedback.
  * Streamlined animated wrapper logic to reduce overhead and enhance visual performance.
  * Minor performance tuning in common UI components (Text, View) without changing their appearance or behavior.

* **Chores**
  * Version bump to 0.8.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->