### PR TITLE
0.8.10

### DIFF
--- a/example/src/ui/CtaButton.tsx
+++ b/example/src/ui/CtaButton.tsx
@@ -5,10 +5,10 @@ import { useTheme, ZSPressable, ZSText } from 'zs-ui';
 interface CtaButtonProps {
   primaryButtonText: string;
   onPrimaryButtonPress: () => void;
-  disabled: boolean;
+  disabled?: boolean;
   backgroundColor?: string;
   bottomComponent?: React.ReactNode;
-  secondaryButtonText: string;
+  secondaryButtonText?: string;
   onSecondaryButtonPress?: () => void;
   onDisabledPress?: () => void;
 }
@@ -16,7 +16,7 @@ interface CtaButtonProps {
 function CtaButton({
   onPrimaryButtonPress,
   primaryButtonText,
-  disabled,
+  disabled = false,
   backgroundColor,
   bottomComponent,
   secondaryButtonText,

--- a/example/src/ui/MyModal.tsx
+++ b/example/src/ui/MyModal.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Button, ScrollView, StyleSheet, View } from 'react-native';
-import { useOverlay, ZSPressable, ZSText, ZSView, useTheme, ZSTextField } from 'zs-ui';
+import { useOverlay, ZSPressable, ZSText, ZSView, useTheme, ZSTextField, ZSAboveKeyboard } from 'zs-ui';
 import { ColorPalette, ThemeBackground } from 'zs-ui/theme';
 import MyBottomSheet from './MyBottomSheet';
+import CtaButton from './CtaButton';
 
 interface MyModalProps {
   onConfirm?: () => void;
@@ -94,6 +95,13 @@ function MyModal({ onConfirm }: MyModalProps) {
           title="show_Alert"
           color="#841584"
         />
+
+        <ZSAboveKeyboard showOnlyKeyboardVisible>
+          <CtaButton
+            primaryButtonText='CTA 버튼'
+            onPrimaryButtonPress={() => { }}
+          />
+        </ZSAboveKeyboard>
       </ScrollView>
     </ZSView >
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",

--- a/src/overlay/ZSPortal/index.tsx
+++ b/src/overlay/ZSPortal/index.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
+import { Z_INDEX_VALUE } from '../../model/utils';
 
 interface PortalContextType {
   registerPortal: (id: string, element: ReactNode) => void;
@@ -43,7 +44,7 @@ export const PortalProvider: React.FC<PortalProviderProps> = ({ children }) => {
     <PortalContext.Provider value={{ registerPortal, unregisterPortal }}>
       {children}
       {Array.from(portals.entries()).map(([id, element]) => (
-        <Animated.View entering={FadeInDown} exiting={FadeOutDown} key={id} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, pointerEvents: 'box-none' }}>
+        <Animated.View entering={FadeInDown} exiting={FadeOutDown} key={id} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, pointerEvents: 'box-none', zIndex: Z_INDEX_VALUE.ABOVE_KEYBOARD }}>
           {element}
         </Animated.View>
       ))}

--- a/src/ui/ZSAboveKeyboard/index.tsx
+++ b/src/ui/ZSAboveKeyboard/index.tsx
@@ -6,6 +6,7 @@ import { ZSPortal } from '../../overlay';
 import useKeyboard from '../../model/useKeyboard';
 
 const screenHeight = Dimensions.get('window').height;
+const HIDDEN_BOTTOM_OFFSET = -300;
 
 interface Props {
   children: React.ReactNode;
@@ -13,6 +14,7 @@ interface Props {
   keyboardHideOffset?: number;
   handleLayoutHeight?: (height: number) => void;
   isFocused?: boolean;
+  showOnlyKeyboardVisible?: boolean;
 }
 
 function ZSAboveKeyboard({
@@ -21,6 +23,7 @@ function ZSAboveKeyboard({
   children,
   handleLayoutHeight,
   isFocused = true,
+  showOnlyKeyboardVisible = false,
 }: Props) {
   const [topValue, setTopValue] = useState(0);
   const componentHeightRef = useRef(0);
@@ -41,9 +44,11 @@ function ZSAboveKeyboard({
     handleLayoutHeight?.(height);
   };
 
+  const isVisible = showOnlyKeyboardVisible ? isKeyboardVisible : true;
+
   return (
     <ZSPortal isFocused={isFocused}>
-      <View style={[styles.container, (isKeyboardVisible && topValue !== 0) ? { top: topValue } : { bottom: keyboardHideOffset + bottom }]}>
+      <View style={[styles.container, !isVisible ? { bottom: HIDDEN_BOTTOM_OFFSET } : isKeyboardVisible ? { top: topValue } : { bottom: keyboardHideOffset + bottom }]}>
         <View onLayout={handleLayout}>
           {children}
         </View>


### PR DESCRIPTION
## Sourcery 요약

키보드를 인식하여 위치를 조정하는 새로운 `ZSAboveKeyboard` 오버레이 컴포넌트를 추가하고, `CtaButton` API를 선택적(optional) 속성을 사용하도록 업데이트하며, 올바른 스태킹을 위해 포털 `z-index`를 조정하고, 예제에 변경사항을 통합하며, 패키지 버전을 `0.8.10`으로 업데이트했습니다.

새로운 기능:
- 키보드 위에 콘텐츠를 배치하는 `ZSAboveKeyboard` 컴포넌트 도입 (선택적으로 `showOnlyKeyboardVisible` 동작 사용 가능)
- `CtaButton`의 `disabled` 및 `secondaryButtonText` 속성을 선택적으로 만들고, 합리적인 기본값 제공

개선 사항:
- 포털이 키보드 위에 렌더링되도록 `ZSPortal` 오버레이에 `zIndex` 값 추가
- 예제 `MyModal` 컴포넌트에 `ZSAboveKeyboard` 및 `CtaButton` 통합

빌드:
- 패키지 버전을 `0.8.10`으로 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new ZSAboveKeyboard overlay component for keyboard-aware positioning, update CtaButton API to use optional props, adjust portal z-index for proper stacking, integrate changes in the example, and bump the package version to 0.8.10

New Features:
- Introduce ZSAboveKeyboard component to position content above the keyboard with optional showOnlyKeyboardVisible behavior
- Make CtaButton props optional for disabled and secondaryButtonText, with sensible defaults

Enhancements:
- Add zIndex value to ZSPortal overlays to ensure portals render above the keyboard
- Integrate ZSAboveKeyboard and CtaButton in the example MyModal component

Build:
- Bump package version to 0.8.10

</details>