### PR TITLE
git action test

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,9 +20,13 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          scope: '@0610studio'
 
-      - name: "Install npm (Trusted Publishing: 11.5.1+)"
-        run: npm install -g npm@^11
+      - name: Install npm 11.5.1+
+        run: npm install -g 'npm@^11.5.1'
+
+      - name: Enable Corepack (Yarn)
+        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary by Sourcery

npm publish GitHub Actions 워크플로를 업데이트하여 특정 npm 11.5.1+ 버전을 사용하고, Yarn을 위해 Corepack을 활성화하며, 배포용 npm 스코프를 설정합니다.

Build:
- 배포를 위해 Node 설정 단계에서 @0610studio npm 스코프를 구성합니다.
- 워크플로에서 전역 npm 설치를 임의의 11.x가 아닌 11.5.1+ 버전으로 고정합니다.
- 의존성을 설치하기 전에 corepack enable을 통해 Yarn을 관리할 수 있도록 워크플로에서 Corepack을 활성화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the npm publish GitHub Actions workflow to use a specific npm 11.5.1+ version, enable Corepack for Yarn, and configure the npm scope for publishing.

Build:
- Configure the Node setup step with the @0610studio npm scope for publishing.
- Pin the npm global install in the workflow to version 11.5.1+ instead of any 11.x.
- Enable Corepack in the workflow to manage Yarn via corepack enable before installing dependencies.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve build and deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->