### PR TITLE
0.19.1

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,6 +1,7 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
+const fs = require('fs');
 
 const config = getDefaultConfig(__dirname);
 
@@ -9,14 +10,34 @@ const config = getDefaultConfig(__dirname);
 // excludes the one from the parent folder when bundling.
 // 경로 끝을 앵커링해 react / react-native 폴더만 정확히 차단합니다.
 // (앵커가 없으면 react-reconciler, react-dom 등 접두어가 같은 루트 패키지까지 차단됨)
-const blockRootPackage = (name) =>
-  new RegExp(`^${path.resolve(__dirname, '..', 'node_modules', name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(/.*)?$`);
+const rootNodeModules = path.resolve(__dirname, '..', 'node_modules');
+const exampleNodeModules = path.resolve(__dirname, 'node_modules');
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const realPathIfExists = (value) => {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return value;
+  }
+};
+const blockRootPackage = (name) => {
+  const packagePaths = [
+    path.resolve(rootNodeModules, name),
+    realPathIfExists(path.resolve(rootNodeModules, name)),
+  ];
+
+  return new RegExp(
+    `^(?:${packagePaths.map(escapeRegExp).join('|')})(/.*)?$`,
+  );
+};
 
 config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),
   blockRootPackage('react'),
   blockRootPackage('react-native'),
   blockRootPackage('react-native-safe-area-context'),
+  blockRootPackage('react-native-reanimated'),
+  blockRootPackage('react-native-worklets'),
 ];
 
 config.resolver.nodeModulesPaths = [
@@ -26,6 +47,10 @@ config.resolver.nodeModulesPaths = [
 
 config.resolver.extraNodeModules = {
   'zs-ui': '..',
+  react: path.resolve(exampleNodeModules, 'react'),
+  'react-native': path.resolve(exampleNodeModules, 'react-native'),
+  'react-native-reanimated': path.resolve(exampleNodeModules, 'react-native-reanimated'),
+  'react-native-worklets': path.resolve(exampleNodeModules, 'react-native-worklets'),
 };
 
 config.watchFolders = [path.resolve(__dirname, '..')];

--- a/src/ui/ZSBorderBeam/index.tsx
+++ b/src/ui/ZSBorderBeam/index.tsx
@@ -228,6 +228,10 @@ function ZSBorderBeam({
 
   return (
     <View style={[styles.container, style]} {...props}>
+      <View onLayout={handleLayout} style={[styles.content, { borderRadius }]}>
+        {children}
+      </View>
+
       {active && hasLayout && (
         <Canvas
           pointerEvents="none"
@@ -238,6 +242,7 @@ function ZSBorderBeam({
               height: canvasHeight,
               top: -glowPadding,
               left: -glowPadding,
+              zIndex: 1,
             },
           ]}
         >
@@ -285,10 +290,6 @@ function ZSBorderBeam({
           </RoundedRect>
         </Canvas>
       )}
-
-      <View onLayout={handleLayout} style={[styles.content, { borderRadius }]}>
-        {children}
-      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary by Sourcery

Metro 설정과 ZSBorderBeam 레이아웃을 조정하여 의존성과 시각적 레이어링을 더 잘 분리합니다.

개선 사항:
- Metro 구성을 업데이트하여 루트 `node_modules`에서 추가 React Native 관련 패키지를 차단 및 별칭 처리하고, 예제 앱의 `node_modules`에서 올바르게 resolve되도록 합니다.
- ZSBorderBeam의 자식 요소와 캔버스 렌더링 순서를 재조정하여 콘텐츠가 글로우 효과 아래에서 렌더링되도록 하고, 적절한 z-index 레이어링을 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Metro config and ZSBorderBeam layout to better isolate dependencies and visual layering.

Enhancements:
- Update Metro configuration to block and alias additional React Native-related packages from the root node_modules and ensure correct resolution from the example app’s node_modules.
- Reorder ZSBorderBeam children and canvas rendering so content is rendered beneath the glow effect with proper z-index layering.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the border beam component’s visual layering so content remains clearly visible beneath the animated border effect.
  - Enhanced example app module resolution to provide more consistent behavior when using linked or symlinked packages.
  - Added safeguards to prevent duplicate package instances for key React Native and animation dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->