### PR TITLE
0.19.1

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,6 +1,7 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
+const fs = require('fs');
 
 const config = getDefaultConfig(__dirname);
 
@@ -9,14 +10,34 @@ const config = getDefaultConfig(__dirname);
 // excludes the one from the parent folder when bundling.
 // 경로 끝을 앵커링해 react / react-native 폴더만 정확히 차단합니다.
 // (앵커가 없으면 react-reconciler, react-dom 등 접두어가 같은 루트 패키지까지 차단됨)
-const blockRootPackage = (name) =>
-  new RegExp(`^${path.resolve(__dirname, '..', 'node_modules', name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(/.*)?$`);
+const rootNodeModules = path.resolve(__dirname, '..', 'node_modules');
+const exampleNodeModules = path.resolve(__dirname, 'node_modules');
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const realPathIfExists = (value) => {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return value;
+  }
+};
+const blockRootPackage = (name) => {
+  const packagePaths = [
+    path.resolve(rootNodeModules, name),
+    realPathIfExists(path.resolve(rootNodeModules, name)),
+  ];
+
+  return new RegExp(
+    `^(?:${packagePaths.map(escapeRegExp).join('|')})(/.*)?$`,
+  );
+};
 
 config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),
   blockRootPackage('react'),
   blockRootPackage('react-native'),
   blockRootPackage('react-native-safe-area-context'),
+  blockRootPackage('react-native-reanimated'),
+  blockRootPackage('react-native-worklets'),
 ];
 
 config.resolver.nodeModulesPaths = [
@@ -26,6 +47,10 @@ config.resolver.nodeModulesPaths = [
 
 config.resolver.extraNodeModules = {
   'zs-ui': '..',
+  react: path.resolve(exampleNodeModules, 'react'),
+  'react-native': path.resolve(exampleNodeModules, 'react-native'),
+  'react-native-reanimated': path.resolve(exampleNodeModules, 'react-native-reanimated'),
+  'react-native-worklets': path.resolve(exampleNodeModules, 'react-native-worklets'),
 };
 
 config.watchFolders = [path.resolve(__dirname, '..')];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0610studio/zs-ui",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": false,
   "description": "EXPO ZS-UI",
   "type": "commonjs",

--- a/src/ui/ZSBorderBeam/index.tsx
+++ b/src/ui/ZSBorderBeam/index.tsx
@@ -228,6 +228,10 @@ function ZSBorderBeam({
 
   return (
     <View style={[styles.container, style]} {...props}>
+      <View onLayout={handleLayout} style={[styles.content, { borderRadius }]}>
+        {children}
+      </View>
+
       {active && hasLayout && (
         <Canvas
           pointerEvents="none"
@@ -238,6 +242,7 @@ function ZSBorderBeam({
               height: canvasHeight,
               top: -glowPadding,
               left: -glowPadding,
+              zIndex: 1,
             },
           ]}
         >
@@ -285,10 +290,6 @@ function ZSBorderBeam({
           </RoundedRect>
         </Canvas>
       )}
-
-      <View onLayout={handleLayout} style={[styles.content, { borderRadius }]}>
-        {children}
-      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary by Sourcery

예제 Metro 번들러 설정을 조정하여 의존성을 올바르게 분리하고, ZSBorderBeam 레이아웃 쌓임 방식을 업데이트하며 버전 0.19.1을 릴리스합니다.

Enhancements:
- 예제 로컬 의존성을 우선 사용하도록 하고, 루트 수준의 React 관련 패키지(예: reanimated 및 worklets 포함)를 견고하게 차단하도록 Metro 설정을 개선합니다.
- 전용 내부 컨테이너와 z-index 스타일링을 사용해 ZSBorderBeam이 콘텐츠를 글로우 캔버스 아래에 렌더링하도록 업데이트하여 올바른 시각적 레이어링을 보장합니다.

Build:
- 예제 앱에서 추가적인 React Native 관련 패키지를 처리할 수 있도록 Metro resolver block list와 extraNodeModules 매핑을 확장합니다.

Chores:
- `package.json`에서 라이브러리 버전을 0.19.1로 상향합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust example Metro bundler configuration to correctly isolate dependencies and update ZSBorderBeam layout stacking while releasing version 0.19.1.

Enhancements:
- Improve Metro config to robustly block root-level React-related packages and prefer example-local dependencies, including reanimated and worklets.
- Update ZSBorderBeam to render its content beneath the glow canvas using a dedicated inner container and z-index styling for correct visual layering.

Build:
- Extend Metro resolver block list and extraNodeModules mappings to handle additional React Native-related packages in the example app.

Chores:
- Bump library version to 0.19.1 in package.json.

</details>